### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
     attributes:
       label: "Lotus & LotusWeb versions"
       description: "Paste the relevant dependency lines from your `mix.exs`"
-      placeholder: '{:lotus, "~> 0.9.2"}, {:lotus_web, "~> 0.5.2"}'
+      placeholder: '{:lotus, "~> 0.9.2"}, {:lotus_web, "~> 0.6.0"}'
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.6.0] - 2025-11-14
+
 ### Changed
 
 - Implement controller-based query export for chunking exports without creating a local temp file (#34):

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 > ⚠️ **Branch & Release Policy**
 >
 > - **Use tagged releases** when adding this package as a dependency.
->   Example: `{:lotus, "~> 0.9.2"}` and `{:lotus_web, "~> 0.5.2"}`
+>   Example: `{:lotus, "~> 0.9.2"}` and `{:lotus_web, "~> 0.6.0"}`
 > - The `main` branch is **development-only** and may not compile or run outside this repo.
 > - Release docs live on HexDocs (links above). The README on `main` may describe unreleased changes.
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.Web.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus_web"
-  @version "0.5.2"
+  @version "0.6.0"
 
   def project do
     [
@@ -19,7 +19,8 @@ defmodule Lotus.Web.MixProject do
       description: description(),
       source_url: @source_url,
       homepage_url: @source_url,
-      dialyzer: dialyzer()
+      dialyzer: dialyzer(),
+      listeners: [Phoenix.CodeReloader]
     ]
   end
 


### PR DESCRIPTION
Bumps version to 0.6.0.

See CHANGELOG for the changes:
```
- Implement controller-based query export for chunking exports without creating a local temp file (#34):
  - Unsaved queries can no longer be exported; only saved queries can be exported. This was done to limit the token size in the URL and avoid exposing the data model (as the SQL query would need to be transmitted with the token).

- **INTERNAL:** Comprehensive Credo-based code quality improvements:
  - Added Credo static code analysis tool with custom configuration
  - Eliminated deeply nested functions by extracting helper functions across components
  - Reduced cyclomatic complexity in multiple modules (raised max to 10 for complex validation functions)
  - Improved predicate function naming conventions (e.g., `is_text_type?` → `text_type?`)
  - Refactored complex case statements and conditional logic for better readability
  - Added `@moduledoc false` annotations to internal modules
  - Configured selective exclusions for `MapJoin` warnings where pipe readability is prioritized
  - Enhanced code maintainability and testability without changing public APIs
```