### PR TITLE
Fix prefixed path generation for exports

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -41,8 +41,8 @@ window.addEventListener("phx:page-loading-stop", (info) => {
   topbar.hide();
 });
 
-window.addEventListener("phx:download-url", (event) => {
-  window.open(event.detail.url, '_blank');
+window.addEventListener("phx:open-blank", (event) => {
+  window.open(event.detail.location, '_blank');
 });
 
 topbar.config({

--- a/lib/lotus/web.ex
+++ b/lib/lotus/web.ex
@@ -1,8 +1,6 @@
 defmodule Lotus.Web do
   @moduledoc false
 
-  alias Lotus.Web.Layouts
-
   def html do
     quote do
       @moduledoc false
@@ -17,7 +15,7 @@ defmodule Lotus.Web do
     quote do
       @moduledoc false
 
-      use Phoenix.LiveView, layout: {Layouts, :live}
+      use Phoenix.LiveView, layout: {Lotus.Web.Layouts, :live}
 
       unquote(html_helpers())
     end

--- a/lib/lotus/web/dashboard_live.ex
+++ b/lib/lotus/web/dashboard_live.ex
@@ -1,5 +1,5 @@
 defmodule Lotus.Web.DashboardLive do
-  use Phoenix.LiveView, layout: {Lotus.Web.Layouts, :live}
+  use Lotus.Web, :live_view
 
   alias Lotus.Web.{QueriesPage, QueryEditorPage}
 
@@ -15,7 +15,7 @@ defmodule Lotus.Web.DashboardLive do
 
     page = resolve_page(params)
 
-    Process.put(:routing, {socket, prefix})
+    put_router_prefix(socket, prefix)
 
     socket =
       socket

--- a/lib/lotus/web/helpers.ex
+++ b/lib/lotus/web/helpers.ex
@@ -5,6 +5,13 @@ defmodule Lotus.Web.Helpers do
 
   # Routing Helpers
 
+  @pdict_key :__lotus_web_prefix__
+
+  @doc false
+  def put_router_prefix(socket, prefix) do
+    Process.put(@pdict_key, {socket, prefix})
+  end
+
   @doc """
   Construct a path to a dashboard page with optional params.
 
@@ -25,7 +32,7 @@ defmodule Lotus.Web.Helpers do
       |> Enum.sort()
       |> encode_params()
 
-    case Process.get(:routing) do
+    case Process.get(@pdict_key) do
       {socket, prefix} ->
         VerifiedRoutes.unverified_path(socket, socket.router, "#{prefix}/#{route}", params)
 
@@ -33,7 +40,7 @@ defmodule Lotus.Web.Helpers do
         "/"
 
       nil ->
-        raise RuntimeError, "nothing stored in the :routing key"
+        raise RuntimeError, "nothing stored in the #{@pdict_key} key"
     end
   end
 

--- a/lib/lotus/web/pages/query_editor_page.ex
+++ b/lib/lotus/web/pages/query_editor_page.ex
@@ -1116,10 +1116,8 @@ defmodule Lotus.Web.QueryEditorPage do
     endpoint = socket.endpoint
     token = ExportController.generate_token(endpoint, export_params)
 
-    prefix = socket.assigns[:prefix] || ""
-    export_url = "#{prefix}/lotus/export/csv?token=#{URI.encode_www_form(token)}"
-
-    push_event(socket, "download-url", %{url: export_url})
+    export_path = lotus_path([:export, :csv], %{token: URI.encode_www_form(token)})
+    push_event(socket, "open-blank", %{location: export_path})
   end
 
   defp delete_query(socket) do


### PR DESCRIPTION
Relates to https://github.com/typhoonworks/lotus_web/issues/34

## Changes

- fix: Use `lotus_path` helper instead of manual path construction with non-existent `assigns[:prefix]`
- drive-by: Replace `:routing` pdict key (conflicting with oban web)
