### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
     attributes:
       label: "Lotus & LotusWeb versions"
       description: "Paste the relevant dependency lines from your `mix.exs`"
-      placeholder: '{:lotus, "~> 0.9.2"}, {:lotus_web, "~> 0.6.0"}'
+      placeholder: '{:lotus, "~> 0.9.2"}, {:lotus_web, "~> 0.6.1"}'
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## Unreleased
 
+## [0.6.1] - 2025-11-18
+
+### Internal
+
 - Added a `release` mix task for use with new releases. `release` task ensures assets are always built before publishing.
 - Changed tailwind config, removing `--watch=always` in `config.exs`, so that the `assets.build` task can be run without blocking.
+
+### Fixed
+
+- `assets.build` was not run for the 0.6.0 release, breaking the download functionality. 0.6.1 includes the built assets.
 
 ## [0.6.0] - 2025-11-14
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 > ⚠️ **Branch & Release Policy**
 >
 > - **Use tagged releases** when adding this package as a dependency.
->   Example: `{:lotus, "~> 0.9.2"}` and `{:lotus_web, "~> 0.6.0"}`
+>   Example: `{:lotus, "~> 0.9.2"}` and `{:lotus_web, "~> 0.6.1"}`
 > - The `main` branch is **development-only** and may not compile or run outside this repo.
 > - Release docs live on HexDocs (links above). The README on `main` may describe unreleased changes.
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.Web.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus_web"
-  @version "0.6.0"
+  @version "0.6.1"
 
   def project do
     [


### PR DESCRIPTION
Bumps version to 0.6.1.

See CHANGELOG for the changes:
```
### Internal

- Added a `release` mix task for use with new releases. `release` task ensures assets are always built before publishing.
- Changed tailwind config, removing `--watch=always` in `config.exs`, so that the `assets.build` task can be run without blocking.

### Fixed

- `assets.build` was not run for the 0.6.0 release, breaking the download functionality. 0.6.1 includes the built assets.
```

Fixes #38 