### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
     attributes:
       label: "Lotus & LotusWeb versions"
       description: "Paste the relevant dependency lines from your `mix.exs`"
-      placeholder: '{:lotus, "~> 0.9.2"}, {:lotus_web, "~> 0.6.1"}'
+      placeholder: '{:lotus, "~> 0.9.2"}, {:lotus_web, "~> 0.6.2"}'
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.6.2] - 2025-11-18
+
 ### Internal
 
 - During build, ESBuild also generates a CSS, which was overriding the Tailwind CSS output, causing all the Tailwind classes to be lost. This has been fixed by updating the Tailwind args to output the CSS files to separate locations.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 > ⚠️ **Branch & Release Policy**
 >
 > - **Use tagged releases** when adding this package as a dependency.
->   Example: `{:lotus, "~> 0.9.2"}` and `{:lotus_web, "~> 0.6.1"}`
+>   Example: `{:lotus, "~> 0.9.2"}` and `{:lotus_web, "~> 0.6.2"}`
 > - The `main` branch is **development-only** and may not compile or run outside this repo.
 > - Release docs live on HexDocs (links above). The README on `main` may describe unreleased changes.
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.Web.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus_web"
-  @version "0.6.1"
+  @version "0.6.2"
 
   def project do
     [


### PR DESCRIPTION
Bumps version to 0.6.2.

See CHANGELOG for the changes:
```
### Internal

- During build, ESBuild also generates a CSS, which was overriding the Tailwind CSS output, causing all the Tailwind classes to be lost. This has been fixed by updating the Tailwind args to output the CSS files to separate locations.
  - While ESBuild still outputs a CSS file, we don't use it because the Tailwind CSS output already contains all the CSS we need.

### Fixed

- Incorrect esbuild configuration was overriding the Tailwind CSS build output, causing missing styles in the published assets.
```

Related to #38 