### PR TITLE
Add locals_without_parens export for lotus_dashboard macro

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,8 @@
 # Used by "mix format"
+locals_without_parens = [lotus_dashboard: 1, lotus_dashboard: 2]
+
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [0.13.1] - 2026-03-05
 
+### Changed
+
+- Added `locals_without_parens` export to `.formatter.exs` so `lotus_dashboard` calls are not reformatted with parentheses in consumer projects
+
 ### Fixed
 
 - Bot icon in the Query Editor toolbar now turns pink when the AI Assistant drawer is open, matching the active-state behavior of other toolbar icons


### PR DESCRIPTION
Prevents mix format from adding parentheses to lotus_dashboard calls in consumer projects.
