### PR TITLE
Fixes #76 - Results pane height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Graceful error handling for JSON encoding failures** - Wrapped `Lotus.JSON.encode!` calls in `ResultsComponent`, `CardComponent`, and `VegaSpecBuilder` with safe encoding that renders user-friendly error messages instead of crashing the LiveView process when results contain non-encodable values (e.g. raw UUID binaries)
 - **Raw database value normalization** - `VegaSpecBuilder` and `ResultsComponent` now use `Lotus.Normalizer` to normalize raw database values (UUID binaries, Dates, Decimals, etc.) before JSON encoding
+- **Results panel height** - Set to `h-full` instead of using CSS calc, increase min-h value
 
 ## [0.14.3] - 2026-03-10
 

--- a/lib/lotus/web/live/queries/results_component.ex
+++ b/lib/lotus/web/live/queries/results_component.ex
@@ -52,7 +52,7 @@ defmodule Lotus.Web.Queries.ResultsComponent do
           <.sort_chips :if={@sorts != []} sorts={@sorts} target={@target} />
 
           <%!-- Content area: Table or Chart --%>
-          <div class="flex-1 min-h-0 overflow-auto">
+          <div class="flex-1 min-h-0 overflow-hidden">
             <%= if @visualization_view_mode == :chart && has_valid_config?(@visualization_config) do %>
               <.render_chart result={@result} config={@visualization_config} />
             <% else %>
@@ -245,7 +245,7 @@ defmodule Lotus.Web.Queries.ResultsComponent do
           phx-hook="VegaChart"
           phx-update="ignore"
           data-spec={@spec_json}
-          class="w-full h-[calc(100vh-420px)] min-h-[250px] max-h-[500px] flex items-center justify-center"
+          class="w-full h-full min-h-[250px] max-h-[500px] flex items-center justify-center"
         >
           <div class="text-gray-400">
             <.spinner />

--- a/lib/lotus/web/live/queries/results_component.ex
+++ b/lib/lotus/web/live/queries/results_component.ex
@@ -52,7 +52,7 @@ defmodule Lotus.Web.Queries.ResultsComponent do
           <.sort_chips :if={@sorts != []} sorts={@sorts} target={@target} />
 
           <%!-- Content area: Table or Chart --%>
-          <div class="flex-1 min-h-0 overflow-hidden">
+          <div class="flex-1 overflow-hidden">
             <%= if @visualization_view_mode == :chart && has_valid_config?(@visualization_config) do %>
               <.render_chart result={@result} config={@visualization_config} />
             <% else %>

--- a/lib/lotus/web/pages/query_editor_page.ex
+++ b/lib/lotus/web/pages/query_editor_page.ex
@@ -118,7 +118,7 @@ defmodule Lotus.Web.QueryEditorPage do
                 />
               </div>
 
-              <div class="flex-1 min-h-0">
+              <div class="flex-1 min-h-1">
                 <.render_result
                   query_id={Map.get(@page, :id, "new")}
                   result={@result}

--- a/lib/lotus/web/pages/query_editor_page.ex
+++ b/lib/lotus/web/pages/query_editor_page.ex
@@ -118,7 +118,7 @@ defmodule Lotus.Web.QueryEditorPage do
                 />
               </div>
 
-              <div class="flex-1 min-h-1">
+              <div class="flex-1">
                 <.render_result
                   query_id={Map.get(@page, :id, "new")}
                   result={@result}


### PR DESCRIPTION
## Issue reference
- Fixes #76 

## Changes

- Set Results pane height to `h-full` instead of using CSS `calc`
- Set `overflow-hidden` to avoid double scrollbar visibility
- Increase minimum height from 0

## Screenshots / Logs (optional)

<img width="3455" height="1820" alt="image" src="https://github.com/user-attachments/assets/ead1580a-eb5e-43f2-8d67-56463489fd43" />

## Breaking changes

- [ ] This PR introduces breaking changes

## Documentation updates

- [ ] Public API changed and docs were updated
- [ ] Guides updated (if applicable)

## Checklist

- [x] I have linked a GitHub issue using "Closes/Fixes/Resolves #<id>" (required)
- [x] I have followed the project's coding standards (please let us know if you aren't sure, we're happy to clarify!)
- [ ] Tests added or updated to cover changes
- [ ] All tests pass locally (mix test)
- [x] Code formatted (mix format)
- [x] Credo is clean (mix credo)
- [x] Dialyzer is clean (mix dialyzer)
- [x] CHANGELOG.md updated, if user-facing behavior changed

## Notes for reviewers (optional)

This avoids hiding the results table / graph when the viewport is not tall enough - reduce browser height and confirm that the results are still shown.