### PR TITLE
Sanitize export filename to prevent header injection (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Security
 
 - **XSS via unsanitized markdown rendering** - `AiAssistantComponent` and dashboard `CardComponent` piped Earmark output straight into `Phoenix.HTML.raw/1`, allowing `<script>` tags, inline event handlers, and `javascript:` URLs to execute in the browser. Rendered markdown is now scrubbed via `HtmlSanitizeEx.markdown_html/1` through the new `Lotus.Web.Markdown.to_safe_html/1` helper
+- **Content-Disposition header injection via unsanitized filename** - `ExportController` interpolated the token-supplied `filename` directly into the `Content-Disposition` header. Filenames are now sanitized to strip double quotes, backslashes, and control characters (including `\r`/`\n`), preventing HTTP response header injection as a defense-in-depth measure
 
 ### Fixed
 

--- a/lib/lotus/web/controllers/export_controller.ex
+++ b/lib/lotus/web/controllers/export_controller.ex
@@ -50,7 +50,10 @@ defmodule Lotus.Web.ExportController do
   defp stream_csv_export(conn, export_params) do
     case build_query(export_params) do
       %Query{} = query ->
-        filename = Map.get(export_params, "filename", "export.csv")
+        filename =
+          export_params
+          |> Map.get("filename", "export.csv")
+          |> sanitize_filename()
 
         conn
         |> put_resp_content_type("text/csv")
@@ -64,6 +67,21 @@ defmodule Lotus.Web.ExportController do
         |> text("Query not found.")
     end
   end
+
+  # Sanitize filename to prevent Content-Disposition header injection.
+  # Strips characters that could break out of the quoted filename or inject
+  # additional headers (double quotes, backslashes, CR/LF, control chars).
+  defp sanitize_filename(filename) when is_binary(filename) do
+    filename
+    |> String.replace(~r/[\x00-\x1f\x7f"\\]/, "")
+    |> String.trim()
+    |> case do
+      "" -> "export.csv"
+      sanitized -> sanitized
+    end
+  end
+
+  defp sanitize_filename(_), do: "export.csv"
 
   defp build_query(%{"query_id" => query_id}) when not is_nil(query_id) do
     Lotus.get_query(query_id)

--- a/test/lotus/web/controllers/export_controller_test.exs
+++ b/test/lotus/web/controllers/export_controller_test.exs
@@ -177,6 +177,86 @@ defmodule Lotus.Web.Controllers.ExportControllerTest do
       assert conn.resp_body =~ "result"
     end
 
+    test "strips CRLF from filename to prevent header injection", %{conn: conn} do
+      query = query_fixture(%{statement: "SELECT 1 as result"})
+
+      params = %{
+        "query_id" => query.id,
+        "repo" => "public",
+        "vars" => %{},
+        "filename" => "evil.csv\"\r\nX-Injected: pwned"
+      }
+
+      token = ExportController.generate_token(Lotus.Web.Endpoint, params)
+      conn = get(conn, ~p"/lotus/export/csv?token=#{token}")
+
+      assert conn.status == 200
+
+      [content_disposition] = get_resp_header(conn, "content-disposition")
+      refute content_disposition =~ ~r/[\r\n]/
+      assert content_disposition == ~s(attachment; filename="evil.csvX-Injected: pwned")
+    end
+
+    test "strips null bytes, backslashes, and double-quotes from filename", %{conn: conn} do
+      query = query_fixture(%{statement: "SELECT 1 as result"})
+
+      params = %{
+        "query_id" => query.id,
+        "repo" => "public",
+        "vars" => %{},
+        "filename" => "my\\\"file\x00.csv"
+      }
+
+      token = ExportController.generate_token(Lotus.Web.Endpoint, params)
+      conn = get(conn, ~p"/lotus/export/csv?token=#{token}")
+
+      assert conn.status == 200
+
+      assert get_resp_header(conn, "content-disposition") == [
+               ~s(attachment; filename="myfile.csv")
+             ]
+    end
+
+    test "falls back to default when sanitized filename is empty", %{conn: conn} do
+      query = query_fixture(%{statement: "SELECT 1 as result"})
+
+      params = %{
+        "query_id" => query.id,
+        "repo" => "public",
+        "vars" => %{},
+        "filename" => ~s("""")
+      }
+
+      token = ExportController.generate_token(Lotus.Web.Endpoint, params)
+      conn = get(conn, ~p"/lotus/export/csv?token=#{token}")
+
+      assert conn.status == 200
+
+      assert get_resp_header(conn, "content-disposition") == [
+               ~s(attachment; filename="export.csv")
+             ]
+    end
+
+    test "falls back to default when filename is only whitespace", %{conn: conn} do
+      query = query_fixture(%{statement: "SELECT 1 as result"})
+
+      params = %{
+        "query_id" => query.id,
+        "repo" => "public",
+        "vars" => %{},
+        "filename" => "   \t  "
+      }
+
+      token = ExportController.generate_token(Lotus.Web.Endpoint, params)
+      conn = get(conn, ~p"/lotus/export/csv?token=#{token}")
+
+      assert conn.status == 200
+
+      assert get_resp_header(conn, "content-disposition") == [
+               ~s(attachment; filename="export.csv")
+             ]
+    end
+
     test "streams CSV with variables", %{conn: conn} do
       create_test_users()
 


### PR DESCRIPTION
The token-supplied filename was interpolated directly into the Content-Disposition header. While Phoenix.Token encryption made exploitation unlikely, strip control chars, double quotes, and backslashes as defense-in-depth against response header injection.