### PR TITLE
Address review findings #105, #107, #108, #109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- **Centralized chart colors in `VegaSpecBuilder`** - 15+ scattered hex literals (gauge/progress fills, delta indicators, waterfall bars, combo accent line, neutral labels, track backgrounds) are now consolidated into a single `@chart_colors` module attribute, exposed via `VegaSpecBuilder.chart_colors/0`, so a future theme/dark-mode pass only has to touch one place (#107)
+- **Extracted duplicated AI action buttons in `AiAssistantComponent`** - The "Explain query" / "Optimize query" buttons were duplicated between the empty state and the input area with slightly different sizing; both now render via a shared `ai_action_buttons` function component that takes a `:size` (`:lg` or `:sm`) and a `:generating` flag (#109)
+- **Use a dedicated salt for export tokens** - `ExportController` now passes `"lotus_export"` as the salt to `Phoenix.Token.encrypt/decrypt` instead of prefixing the full `secret_key_base`. This follows the Phoenix convention and lets the framework handle key derivation internally (#108)
 - **Extracted duplicated data source resolution in `QueryEditorPage`** - The four AI-related event handlers (`send_ai_message`, `optimize_query`, `explain_query`, `explain_fragment`) each inlined the same fallback-to-default-repo logic; this is now a single `resolve_data_source/1` private helper (#106)
 - **Consolidated `PublicDashboardLive` into `DashboardLive`** - Removed ~95% duplicated callbacks by unifying the two LiveViews. The `/public/:token` route now mounts `DashboardLive`, which resolves a `:public_dashboard` page via `resolve_page/1` and branches mount defaults on the existing `public_view` assign (#104)
 
@@ -15,6 +18,7 @@
 
 ### Fixed
 
+- **`SourcesMap.load_database/1` no longer silently swallows exceptions** - The bare `rescue _ -> nil` clause now logs a warning with the database name and the exception message before returning `nil`, so configuration errors, connection failures, and adapter issues are diagnosable instead of silently dropping a database from the explorer (#105)
 - **N+1 query on the Queries page dashboards tab** - `QueriesPage` previously issued one `list_dashboard_cards` query per dashboard while preloading card counts. It now uses the new `Lotus.list_dashboards(preload: [:cards])` option, collapsing the load into a single query (#103)
 - **Graceful error handling for JSON encoding failures** - Wrapped `Lotus.JSON.encode!` calls in `ResultsComponent`, `CardComponent`, and `VegaSpecBuilder` with safe encoding that renders user-friendly error messages instead of crashing the LiveView process when results contain non-encodable values (e.g. raw UUID binaries)
 - **Raw database value normalization** - `VegaSpecBuilder` and `ResultsComponent` now use `Lotus.Normalizer` to normalize raw database values (UUID binaries, Dates, Decimals, etc.) before JSON encoding

--- a/lib/lotus/web/controllers/export_controller.ex
+++ b/lib/lotus/web/controllers/export_controller.ex
@@ -11,6 +11,7 @@ defmodule Lotus.Web.ExportController do
   plug(:fetch_query_params)
 
   @max_age 300
+  @token_salt "lotus_export"
 
   @doc """
   Streams a CSV export directly to the response.
@@ -25,7 +26,7 @@ defmodule Lotus.Web.ExportController do
   def csv(conn, %{"token" => token}) do
     endpoint = Phoenix.Controller.endpoint_module(conn)
 
-    case Phoenix.Token.decrypt(endpoint, secret(endpoint), token, max_age: @max_age) do
+    case Phoenix.Token.decrypt(endpoint, @token_salt, token, max_age: @max_age) do
       {:ok, export_params} ->
         stream_csv_export(conn, export_params)
 
@@ -137,8 +138,6 @@ defmodule Lotus.Web.ExportController do
   Returns a signed token valid for #{@max_age} seconds.
   """
   def generate_token(endpoint, params) do
-    Phoenix.Token.encrypt(endpoint, secret(endpoint), params, max_age: @max_age)
+    Phoenix.Token.encrypt(endpoint, @token_salt, params, max_age: @max_age)
   end
-
-  defp secret(endpoint), do: "lotus:" <> endpoint.config(:secret_key_base)
 end

--- a/lib/lotus/web/live/queries/ai_assistant_component.ex
+++ b/lib/lotus/web/live/queries/ai_assistant_component.ex
@@ -136,46 +136,76 @@ defmodule Lotus.Web.Queries.AiAssistantComponent do
         <p class="text-xs text-gray-400 dark:text-gray-500 mb-2">
           <%= gettext("or use AI on your current query") %>
         </p>
-        <div class="flex items-center gap-2">
-          <button
-            type="button"
-            phx-click="explain_query"
-            phx-target={@parent}
-            disabled={is_nil(@current_sql) or @current_sql == ""}
-            title={gettext("Get a plain-language explanation of your SQL query")}
-            class={[
-              "inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors",
-              if(is_nil(@current_sql) or @current_sql == "",
-                do: "text-gray-400 dark:text-gray-600 border-gray-200 dark:border-gray-700 cursor-not-allowed",
-                else: "text-cyan-700 dark:text-cyan-300 border-cyan-300 dark:border-cyan-600 hover:bg-cyan-50 dark:hover:bg-cyan-900/20"
-              )
-            ]}
-          >
-            <Icons.brain class="h-3.5 w-3.5" />
-            <%= gettext("Explain query") %>
-          </button>
-          <button
-            type="button"
-            phx-click="optimize_query"
-            phx-target={@parent}
-            disabled={is_nil(@current_sql) or @current_sql == ""}
-            title={gettext("Analyze your SQL and suggest performance improvements")}
-            class={[
-              "inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors",
-              if(is_nil(@current_sql) or @current_sql == "",
-                do: "text-gray-400 dark:text-gray-600 border-gray-200 dark:border-gray-700 cursor-not-allowed",
-                else: "text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20"
-              )
-            ]}
-          >
-            <Icons.wrench class="h-3.5 w-3.5" />
-            <%= gettext("Optimize query") %>
-          </button>
-        </div>
+        <.ai_action_buttons
+          parent={@parent}
+          current_sql={@current_sql}
+          generating={false}
+          size={:lg}
+        />
       </div>
     </div>
     """
   end
+
+  attr(:parent, :any, required: true)
+  attr(:current_sql, :string, default: nil)
+  attr(:generating, :boolean, default: false)
+  attr(:size, :atom, values: [:sm, :lg], default: :sm)
+
+  defp ai_action_buttons(assigns) do
+    ~H"""
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        phx-click="explain_query"
+        phx-target={@parent}
+        disabled={ai_action_disabled?(@generating, @current_sql)}
+        title={gettext("Get a plain-language explanation of your SQL query")}
+        class={[
+          ai_action_base_classes(@size),
+          if(ai_action_disabled?(@generating, @current_sql),
+            do: ai_action_disabled_classes(@size),
+            else: "text-cyan-700 dark:text-cyan-300 border-cyan-300 dark:border-cyan-600 hover:bg-cyan-50 dark:hover:bg-cyan-900/20"
+          )
+        ]}
+      >
+        <Icons.brain class="h-3.5 w-3.5" />
+        <%= gettext("Explain query") %>
+      </button>
+      <button
+        type="button"
+        phx-click="optimize_query"
+        phx-target={@parent}
+        disabled={ai_action_disabled?(@generating, @current_sql)}
+        title={gettext("Analyze your SQL and suggest performance improvements")}
+        class={[
+          ai_action_base_classes(@size),
+          if(ai_action_disabled?(@generating, @current_sql),
+            do: ai_action_disabled_classes(@size),
+            else: "text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20"
+          )
+        ]}
+      >
+        <Icons.wrench class="h-3.5 w-3.5" />
+        <%= gettext("Optimize query") %>
+      </button>
+    </div>
+    """
+  end
+
+  defp ai_action_disabled?(generating, current_sql),
+    do: generating or is_nil(current_sql) or current_sql == ""
+
+  defp ai_action_base_classes(:lg),
+    do:
+      "inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors"
+
+  defp ai_action_base_classes(:sm),
+    do:
+      "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md border transition-colors"
+
+  defp ai_action_disabled_classes(_size),
+    do: "text-gray-400 dark:text-gray-600 border-gray-200 dark:border-gray-700 cursor-not-allowed"
 
   attr(:message, :map, required: true)
   attr(:index, :integer, required: true)
@@ -391,41 +421,13 @@ defmodule Lotus.Web.Queries.AiAssistantComponent do
   defp input_area(assigns) do
     ~H"""
     <div class="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 p-4">
-      <div class="mb-2 flex items-center gap-2">
-        <button
-          type="button"
-          phx-click="explain_query"
-          phx-target={@parent}
-          disabled={@generating or is_nil(@current_sql) or @current_sql == ""}
-          title={gettext("Get a plain-language explanation of your SQL query")}
-          class={[
-            "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors",
-            if(@generating or is_nil(@current_sql) or @current_sql == "",
-              do: "text-gray-400 dark:text-gray-600 border border-gray-200 dark:border-gray-700 cursor-not-allowed",
-              else: "text-cyan-700 dark:text-cyan-300 border border-cyan-300 dark:border-cyan-600 hover:bg-cyan-50 dark:hover:bg-cyan-900/20"
-            )
-          ]}
-        >
-          <Icons.brain class="h-3.5 w-3.5" />
-          <%= gettext("Explain query") %>
-        </button>
-        <button
-          type="button"
-          phx-click="optimize_query"
-          phx-target={@parent}
-          disabled={@generating or is_nil(@current_sql) or @current_sql == ""}
-          title={gettext("Analyze your SQL and suggest performance improvements")}
-          class={[
-            "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors",
-            if(@generating or is_nil(@current_sql) or @current_sql == "",
-              do: "text-gray-400 dark:text-gray-600 border border-gray-200 dark:border-gray-700 cursor-not-allowed",
-              else: "text-amber-700 dark:text-amber-300 border border-amber-300 dark:border-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20"
-            )
-          ]}
-        >
-          <Icons.wrench class="h-3.5 w-3.5" />
-          <%= gettext("Optimize query") %>
-        </button>
+      <div class="mb-2">
+        <.ai_action_buttons
+          parent={@parent}
+          current_sql={@current_sql}
+          generating={@generating}
+          size={:sm}
+        />
       </div>
       <form id="ai-message-form" phx-submit="send_ai_message" phx-target={@parent}>
         <div class="flex gap-2">

--- a/lib/lotus/web/sources_map.ex
+++ b/lib/lotus/web/sources_map.ex
@@ -3,6 +3,8 @@ defmodule Lotus.Web.SourcesMap do
   Data structure representing the complete database schema hierarchy.
   """
 
+  require Logger
+
   defstruct databases: []
 
   defmodule Database do
@@ -46,7 +48,13 @@ defmodule Lotus.Web.SourcesMap do
         schemas: schemas
       }
     rescue
-      _ -> nil
+      error ->
+        Logger.warning(
+          "Failed to load database #{inspect(db_name)} for the explorer: " <>
+            Exception.message(error)
+        )
+
+        nil
     end
   end
 

--- a/lib/lotus/web/vega_spec_builder.ex
+++ b/lib/lotus/web/vega_spec_builder.ex
@@ -5,6 +5,21 @@ defmodule Lotus.Web.VegaSpecBuilder do
 
   use Gettext, backend: Lotus.Web.Gettext
 
+  # Centralized chart color palette. Kept in one place so visualization marks
+  # share the same accents and a future theme/dark-mode pass only has to touch
+  # this map.
+  @chart_colors %{
+    primary: "#ec4899",
+    positive: "#10b981",
+    negative: "#ef4444",
+    neutral: "#6b7280",
+    track: "#e5e7eb",
+    accent: "#f97316"
+  }
+
+  @doc "Returns the chart color palette used for built-in visualizations."
+  def chart_colors, do: @chart_colors
+
   @chart_type_ids ~w(bar horizontal_bar line area combo scatter bubble histogram heatmap pie donut funnel waterfall kpi trend gauge progress sparkline)
 
   @doc "Returns the ordered list of chart type ID strings."
@@ -509,7 +524,7 @@ defmodule Lotus.Web.VegaSpecBuilder do
             "align" => "center",
             "baseline" => "middle",
             "dy" => 30,
-            "color" => "#6b7280"
+            "color" => @chart_colors.neutral
           },
           "encoding" => %{
             "text" => %{"field" => "_label", "type" => "nominal"}
@@ -594,7 +609,7 @@ defmodule Lotus.Web.VegaSpecBuilder do
             "outerRadius" => 80,
             "theta" => end_angle,
             "theta2" => start_angle,
-            "color" => "#e5e7eb"
+            "color" => @chart_colors.track
           }
         },
         # Foreground arc (value)
@@ -605,7 +620,7 @@ defmodule Lotus.Web.VegaSpecBuilder do
             "outerRadius" => 80,
             "theta" => value_angle,
             "theta2" => start_angle,
-            "color" => "#ec4899"
+            "color" => @chart_colors.primary
           }
         },
         # Value text
@@ -630,7 +645,7 @@ defmodule Lotus.Web.VegaSpecBuilder do
             "align" => "center",
             "baseline" => "middle",
             "dy" => 20,
-            "color" => "#6b7280"
+            "color" => @chart_colors.neutral
           },
           "encoding" => %{
             "text" => %{"value" => label}
@@ -671,7 +686,12 @@ defmodule Lotus.Web.VegaSpecBuilder do
       "layer" => [
         # Background bar
         %{
-          "mark" => %{"type" => "bar", "height" => 24, "cornerRadius" => 4, "color" => "#e5e7eb"},
+          "mark" => %{
+            "type" => "bar",
+            "height" => 24,
+            "cornerRadius" => 4,
+            "color" => @chart_colors.track
+          },
           "encoding" => %{
             "x" => %{
               "field" => "_value",
@@ -688,7 +708,7 @@ defmodule Lotus.Web.VegaSpecBuilder do
             "type" => "bar",
             "height" => 24,
             "cornerRadius" => 4,
-            "color" => "#ec4899"
+            "color" => @chart_colors.primary
           },
           "encoding" => %{
             "x" => %{
@@ -722,7 +742,7 @@ defmodule Lotus.Web.VegaSpecBuilder do
             "align" => "center",
             "baseline" => "middle",
             "dy" => 30,
-            "color" => "#6b7280"
+            "color" => @chart_colors.neutral
           },
           "encoding" => %{
             "text" => %{"value" => label}
@@ -772,7 +792,7 @@ defmodule Lotus.Web.VegaSpecBuilder do
             "align" => "center",
             "baseline" => "middle",
             "dy" => 10,
-            "color" => "#6b7280"
+            "color" => @chart_colors.neutral
           },
           "encoding" => %{
             "text" => %{"value" => label}
@@ -812,17 +832,17 @@ defmodule Lotus.Web.VegaSpecBuilder do
     extract_numeric(second_row, value_field, nil)
   end
 
-  defp format_delta(_current, nil), do: {"", "#6b7280"}
-  defp format_delta(_current, 0), do: {"", "#6b7280"}
-  defp format_delta(_current, +0.0), do: {"", "#6b7280"}
+  defp format_delta(_current, nil), do: {"", @chart_colors.neutral}
+  defp format_delta(_current, 0), do: {"", @chart_colors.neutral}
+  defp format_delta(_current, +0.0), do: {"", @chart_colors.neutral}
 
   defp format_delta(current, comparison) do
     pct = Float.round((current - comparison) / abs(comparison) * 100, 1)
 
     if pct >= 0 do
-      {"\u25B2 +#{pct}%", "#10b981"}
+      {"\u25B2 +#{pct}%", @chart_colors.positive}
     else
-      {"\u25BC #{pct}%", "#ef4444"}
+      {"\u25BC #{pct}%", @chart_colors.negative}
     end
   end
 
@@ -845,7 +865,8 @@ defmodule Lotus.Web.VegaSpecBuilder do
           "as" => "_prev_cumulative"
         },
         %{
-          "calculate" => "datum['#{y_field}'] >= 0 ? '#10b981' : '#ef4444'",
+          "calculate" =>
+            "datum['#{y_field}'] >= 0 ? '#{@chart_colors.positive}' : '#{@chart_colors.negative}'",
           "as" => "_color"
         }
       ],
@@ -913,7 +934,7 @@ defmodule Lotus.Web.VegaSpecBuilder do
     layers =
       if y2_field && y2_field != "" do
         line_layer = %{
-          "mark" => %{"type" => "line", "point" => true, "color" => "#f97316"},
+          "mark" => %{"type" => "line", "point" => true, "color" => @chart_colors.accent},
           "encoding" => %{
             "x" => %{
               "field" => x_field,

--- a/test/lotus/web/controllers/export_controller_test.exs
+++ b/test/lotus/web/controllers/export_controller_test.exs
@@ -57,7 +57,7 @@ defmodule Lotus.Web.Controllers.ExportControllerTest do
       expired_token =
         Phoenix.Token.encrypt(
           Lotus.Web.Endpoint,
-          "lotus:" <> Lotus.Web.Endpoint.config(:secret_key_base),
+          "lotus_export",
           params,
           signed_at: System.system_time(:second) - 400
         )


### PR DESCRIPTION
- #105: Log a warning in `SourcesMap.load_database/1` instead of swallowing exceptions silently, so configuration/connection issues are diagnosable instead of dropping a database from the explorer.
- #107: Consolidate the 15+ hardcoded hex colors scattered across `VegaSpecBuilder` into a single `@chart_colors` module attribute (exposed via `chart_colors/0`), so a future theme/dark-mode pass only has to touch one place.
- #108: Use a dedicated `"lotus_export"` salt for `Phoenix.Token` encrypt/decrypt in `ExportController` instead of prefixing the full `secret_key_base`, following the Phoenix convention. Test updated to match.
- #109: Extract a shared `ai_action_buttons` function component in `AiAssistantComponent` with `:size` (`:lg`/`:sm`) and `:generating` flags, replacing the duplicated Explain/Optimize buttons in the empty state and the input area.