### PR TITLE
feat(pro): add Pro UI integration mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **Pro UI integration mechanism** — `Lotus.Web.Pro` helper module enables `lotus_pro` to contribute pages, nav items, and slot content into the dashboard at runtime via `Code.ensure_loaded?/1`, with zero compile-time coupling. `DashboardLive.resolve_page/1` now falls back to Pro pages, and the layout renders Pro nav items when available (#9)
+
 ### Changed
 
 - **Centralized chart colors in `VegaSpecBuilder`** - 15+ scattered hex literals (gauge/progress fills, delta indicators, waterfall bars, combo accent line, neutral labels, track backgrounds) are now consolidated into a single `@chart_colors` module attribute, exposed via `VegaSpecBuilder.chart_colors/0`, so a future theme/dark-mode pass only has to touch one place (#107)

--- a/lib/lotus/web/components/layouts/live.html.heex
+++ b/lib/lotus/web/components/layouts/live.html.heex
@@ -6,10 +6,18 @@
   <nav class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
     <div class="mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex h-16 justify-between">
-        <div class="flex">
+        <div class="flex items-center gap-6">
           <div class="flex items-center">
             <.logo />
           </div>
+          <.link
+            :for={item <- Lotus.Web.Pro.nav_items(assigns)}
+            :if={not Map.get(assigns, :public_view, false)}
+            navigate={lotus_path(item.path)}
+            class="text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+          >
+            <%= item.label %>
+          </.link>
         </div>
         <div class="flex items-center space-x-2 sm:space-x-4">
           <%= if not Map.get(assigns, :public_view, false) do %>

--- a/lib/lotus/web/dashboard_live.ex
+++ b/lib/lotus/web/dashboard_live.ex
@@ -103,5 +103,12 @@ defmodule Lotus.Web.DashboardLive do
   defp resolve_page(%{"page" => "dashboards", "id" => id}),
     do: %{name: :dashboard_edit, comp: DashboardEditorPage, mode: :edit, id: id}
 
+  defp resolve_page(%{"page" => slug}) do
+    case Enum.find(Lotus.Web.Pro.extra_pages(), &(&1.slug == slug)) do
+      nil -> resolve_page(%{})
+      %{name: name, component: comp} -> %{name: name, comp: comp}
+    end
+  end
+
   defp resolve_page(_params), do: %{name: :home, comp: QueriesPage}
 end

--- a/lib/lotus/web/pro.ex
+++ b/lib/lotus/web/pro.ex
@@ -1,0 +1,37 @@
+defmodule Lotus.Web.Pro do
+  @moduledoc false
+
+  @pro_web Lotus.Pro.Web
+
+  @doc """
+  Returns `true` if `Lotus.Pro.Web` is available at runtime.
+  """
+  @spec available?() :: boolean()
+  def available? do
+    Code.ensure_loaded?(@pro_web)
+  end
+
+  @doc """
+  Returns Pro page descriptors, or `[]` if Pro is not installed.
+  """
+  @spec extra_pages() :: [map()]
+  def extra_pages do
+    if available?(), do: apply(@pro_web, :pages, []), else: []
+  end
+
+  @doc """
+  Returns Pro nav item descriptors for the given assigns, or `[]` if Pro is not installed.
+  """
+  @spec nav_items(map()) :: [map()]
+  def nav_items(assigns) do
+    if available?(), do: apply(@pro_web, :nav_items, [assigns]), else: []
+  end
+
+  @doc """
+  Renders Pro slot content, or `nil` if Pro is not installed.
+  """
+  @spec render_slot(atom(), map()) :: term() | nil
+  def render_slot(name, assigns) do
+    if available?(), do: apply(@pro_web, :render_slot, [name, assigns]), else: nil
+  end
+end

--- a/test/lotus/web/pro_integration_test.exs
+++ b/test/lotus/web/pro_integration_test.exs
@@ -1,0 +1,30 @@
+defmodule Lotus.Web.ProIntegrationTest do
+  use Lotus.Web.Case
+
+  import Phoenix.LiveViewTest
+
+  describe "DashboardLive resolve_page/1 regression" do
+    test "queries page still resolves" do
+      {:ok, _live, html} = live(build_conn(), "/lotus/queries")
+
+      assert html =~ "No saved queries yet."
+    end
+
+    test "unknown page slug falls back to home" do
+      {:ok, _live, html} = live(build_conn(), "/lotus/nonexistent")
+
+      assert html =~ "No saved queries yet."
+    end
+  end
+
+  describe "layout nav without Pro" do
+    test "does not render Pro nav items" do
+      {:ok, live, _html} = live(build_conn(), "/lotus")
+
+      # Only built-in nav elements should be present
+      assert has_element?(live, "#new-item-dropdown button", "New")
+      # No Pro nav links in the nav bar
+      refute has_element?(live, "nav a[data-pro-nav]")
+    end
+  end
+end

--- a/test/lotus/web/pro_test.exs
+++ b/test/lotus/web/pro_test.exs
@@ -1,0 +1,29 @@
+defmodule Lotus.Web.ProTest do
+  use ExUnit.Case, async: true
+
+  alias Lotus.Web.Pro
+
+  describe "available?/0" do
+    test "returns false when Lotus.Pro.Web is not loaded" do
+      refute Pro.available?()
+    end
+  end
+
+  describe "extra_pages/0" do
+    test "returns empty list when Pro is not available" do
+      assert Pro.extra_pages() == []
+    end
+  end
+
+  describe "nav_items/1" do
+    test "returns empty list when Pro is not available" do
+      assert Pro.nav_items(%{}) == []
+    end
+  end
+
+  describe "render_slot/2" do
+    test "returns nil when Pro is not available" do
+      assert Pro.render_slot(:header, %{}) == nil
+    end
+  end
+end


### PR DESCRIPTION
Adds Lotus.Web.Pro helper module that detects lotus_pro at runtime via Code.ensure_loaded?/1 and delegates page, nav item, and slot rendering. Wires Pro page fallback into DashboardLive.resolve_page/1 and Pro nav items into the layout. Zero compile-time coupling with lotus_pro.