### PR TITLE
Add Elixir 1.19 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
               elixir: "1.18"
               erlang: "27.3.2"
               postgres: "15.8-alpine"
+          - tuple:
+              elixir: "1.19"
+              erlang: "27.3.2"
+              postgres: "15.8-alpine"
 
     env:
       MIX_ENV: test


### PR DESCRIPTION
Match the lotus repo by testing against Elixir 1.19 + OTP 27.3.2.