### PR TITLE
Prepare 0.14.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## [0.14.5] - 2026-04-25
+
+### Fixed
+
+- **Dashboard filter default values on page load** - Filters with configured default values now apply those defaults when the corresponding query parameter is missing from the URL, on both the dashboard editor and public dashboard pages
+
+## [0.14.4] - 2026-03-11
+
 ### Fixed
 
 - **Graceful error handling for JSON encoding failures** - Wrapped `Lotus.JSON.encode!` calls in `ResultsComponent`, `CardComponent`, and `VegaSpecBuilder` with safe encoding that renders user-friendly error messages instead of crashing the LiveView process when results contain non-encodable values (e.g. raw UUID binaries)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.Web.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/typhoonworks/lotus_web"
-  @version "0.14.4"
+  @version "0.14.5"
 
   def project do
     [


### PR DESCRIPTION
## Summary
- Bump version to 0.14.5 in `mix.exs`
- Add 0.14.5 entry to `CHANGELOG.md` covering the dashboard filter default values fix (#134)