### PR TITLE
Add :include_views option to surface views in the schema explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **`:include_views` option for the schema explorer** — set `config :lotus_web, include_views: true` (or pass `include_views: true` to `SourcesMap.build/1`) to list database views — including materialized views and PostgreSQL/TimescaleDB continuous aggregates — in the schema explorer and SQL autocomplete alongside base tables. Defaults to `false`, preserving existing behavior
 - **Pro UI integration mechanism** — `Lotus.Web.Pro` helper module enables `lotus_pro` to contribute pages, nav items, and slot content into the dashboard at runtime via `Code.ensure_loaded?/1`, with zero compile-time coupling. `DashboardLive.resolve_page/1` now falls back to Pro pages, and the layout renders Pro nav items when available (#9)
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ lotus_dashboard "/lotus",
 |---------|-------------|
 | `:timeout_options` | Adds a per-query timeout selector (5s to 5m) to the editor toolbar |
 
+### Including Views
+
+By default the schema explorer and SQL autocomplete list only base tables.
+Set `:include_views` to also surface database views — including materialized
+views and PostgreSQL/TimescaleDB continuous aggregates:
+
+```elixir
+# config/config.exs
+config :lotus_web, include_views: true
+```
+
 ### Caching (Optional, Recommended)
 
 Add Lotus to your supervision tree and configure cache settings:

--- a/lib/lotus/web/sources_map.ex
+++ b/lib/lotus/web/sources_map.ex
@@ -19,16 +19,34 @@ defmodule Lotus.Web.SourcesMap do
     defstruct [:name, :is_default, :display_name, tables: []]
   end
 
-  def build() do
+  @doc """
+  Builds the complete sources map for all configured data sources.
+
+  ## Options
+
+    * `:include_views` — when `true`, database views (including materialized
+      views and PostgreSQL/TimescaleDB continuous aggregates) are listed in the
+      schema explorer and SQL autocomplete alongside base tables. Defaults to
+      the `:lotus_web, :include_views` application config, which itself defaults
+      to `false`:
+
+          config :lotus_web, include_views: true
+
+  """
+  def build(opts \\ []) do
+    include_views? = Keyword.get(opts, :include_views, default_include_views?())
+
     databases =
       Lotus.list_data_source_names()
-      |> Enum.map(&load_database/1)
+      |> Enum.map(&load_database(&1, include_views?))
       |> Enum.reject(&is_nil/1)
 
     %__MODULE__{databases: databases}
   end
 
-  defp load_database(db_name) do
+  defp default_include_views?, do: Application.get_env(:lotus_web, :include_views, false)
+
+  defp load_database(db_name, include_views?) do
     source_type = Lotus.Sources.source_type(db_name)
     supports_schemas = Lotus.Sources.supports_feature?(source_type, :schema_hierarchy)
 
@@ -36,9 +54,9 @@ defmodule Lotus.Web.SourcesMap do
 
     schemas =
       if supports_schemas do
-        load_postgres_schemas(db_name, repo)
+        load_postgres_schemas(db_name, repo, include_views?)
       else
-        load_simple_tables(db_name)
+        load_simple_tables(db_name, include_views?)
       end
 
     %Database{
@@ -65,11 +83,12 @@ defmodule Lotus.Web.SourcesMap do
       nil
   end
 
-  defp load_postgres_schemas(db_name, repo) do
+  defp load_postgres_schemas(db_name, repo, include_views?) do
     with {:ok, schema_names} <- Lotus.list_schemas(db_name),
          [default_schema | _] <- Lotus.Source.default_schemas(repo),
          search_path <- Enum.join(schema_names, ","),
-         {:ok, all_tables} <- Lotus.list_tables(db_name, search_path: search_path) do
+         {:ok, all_tables} <-
+           Lotus.list_tables(db_name, search_path: search_path, include_views: include_views?) do
       all_tables
       |> Enum.group_by(fn {schema, _table} -> schema end, fn {_schema, table} -> table end)
       |> Enum.map(fn {schema_name, tables} ->
@@ -88,8 +107,8 @@ defmodule Lotus.Web.SourcesMap do
     end
   end
 
-  defp load_simple_tables(db_name) do
-    case Lotus.list_tables(db_name) do
+  defp load_simple_tables(db_name, include_views?) do
+    case Lotus.list_tables(db_name, include_views: include_views?) do
       {:ok, tables} ->
         table_names = extract_table_names(tables)
 

--- a/test/lotus/web/sources_map_config_test.exs
+++ b/test/lotus/web/sources_map_config_test.exs
@@ -1,0 +1,40 @@
+defmodule Lotus.Web.SourcesMapConfigTest do
+  # async: false because this mutates the global :lotus_web :include_views
+  # application env, which SourcesMap.build/1 reads as its default.
+  use Lotus.Web.Case, async: false
+
+  alias Lotus.Web.SourcesMap
+
+  setup do
+    original = Application.get_env(:lotus_web, :include_views)
+
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:lotus_web, :include_views)
+        value -> Application.put_env(:lotus_web, :include_views, value)
+      end
+    end)
+
+    :ok
+  end
+
+  defp public_tables(sources_map) do
+    sources_map
+    |> SourcesMap.get_database("public")
+    |> Map.fetch!(:schemas)
+    |> Enum.find(&(&1.name == "public"))
+    |> Map.fetch!(:tables)
+  end
+
+  test "build/0 includes views when :lotus_web :include_views config is true" do
+    Application.put_env(:lotus_web, :include_views, true)
+
+    assert "active_test_users" in public_tables(SourcesMap.build())
+  end
+
+  test "an explicit include_views option overrides the config" do
+    Application.put_env(:lotus_web, :include_views, true)
+
+    refute "active_test_users" in public_tables(SourcesMap.build(include_views: false))
+  end
+end

--- a/test/lotus/web/sources_map_test.exs
+++ b/test/lotus/web/sources_map_test.exs
@@ -4,6 +4,30 @@ defmodule Lotus.Web.SourcesMapTest do
   alias Lotus.Web.SourcesMap
   alias Lotus.Web.SourcesMap.{Database, Schema}
 
+  defp public_tables(sources_map) do
+    sources_map
+    |> SourcesMap.get_database("public")
+    |> Map.fetch!(:schemas)
+    |> Enum.find(&(&1.name == "public"))
+    |> Map.fetch!(:tables)
+  end
+
+  describe "build/1 with :include_views" do
+    test "excludes views by default" do
+      tables = public_tables(SourcesMap.build())
+
+      assert "test_users" in tables
+      refute "active_test_users" in tables
+    end
+
+    test "includes views when include_views: true" do
+      tables = public_tables(SourcesMap.build(include_views: true))
+
+      assert "test_users" in tables
+      assert "active_test_users" in tables
+    end
+  end
+
   describe "build/0" do
     test "builds complete sources map with all configured databases" do
       sources_map = SourcesMap.build()

--- a/test/support/postgres/migrations/00_create_test_tables.exs
+++ b/test/support/postgres/migrations/00_create_test_tables.exs
@@ -26,5 +26,11 @@ defmodule Lotus.Test.Repo.Migrations.CreateTestTables do
 
     create(index(:test_posts, [:user_id]))
     create(index(:test_posts, [:published]))
+
+    # A view, so the schema explorer's view-inclusion behavior can be exercised.
+    execute(
+      "CREATE VIEW active_test_users AS SELECT id, name, email FROM test_users WHERE active",
+      "DROP VIEW active_test_users"
+    )
   end
 end


### PR DESCRIPTION
**Disclaimer:** Opened with Claude Opus 4.8 with supervision. 

## Problem

The schema explorer and SQL autocomplete are sourced from `SourcesMap.build/0`, which calls `Lotus.list_tables/2` without `include_views`. Since that option defaults to `false`, only base tables are listed. 

That's a sensible default, but ideally, users would be able to configure their `lotus_web` dashboard to include views from the jump.

## Change

Add an `:include_views` option to `SourcesMap.build/1`:

- Defaults to the `:lotus_web, :include_views` application config, which itself defaults to `false` so there's no behavior change** for existing users.
- When enabled, `include_views: true` is threaded through to `Lotus.list_tables/2` in both the Postgres (schema-aware) and simple table-listing paths.

```elixir
# config/config.exs
config :lotus_web, include_views: true
```

The two internal callers (`QueryEditorPage`, `SchemaExplorerComponent`) keep calling `build()` with no args and pick up the config automatically. The explicit option is primarily for tests and programmatic callers, and overrides the config when given.

## Tests

Added test-first:

- A `active_test_users` **view** fixture to the test schema (`00_create_test_tables.exs`).
- `SourcesMapTest`: views excluded by default; included with `build(include_views: true)`.
- `SourcesMapConfigTest` (`async: false`): `build/0` honors the `:lotus_web, :include_views` config; an explicit option overrides the config.

Full suite green (`268 passed`); `mix format --check-formatted` clean.

## Docs

- README: new "Including Views" configuration subsection.
- CHANGELOG: entry under Unreleased → Added.