### PR TITLE
Prepare release v0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.14.7] - 2026-07-12
+
 ### Changed
 
 - Replaced the retired, unmaintained `earmark` Markdown dependency with the actively maintained `mdex`, which is not subject to the security advisory affecting `earmark`. Markdown rendering now routes through a single `Lotus.Web.Markdown.to_safe_html/1` chokepoint. Also bumped `ex_doc` `0.38` → `0.40` (dev/test only). ([#138](https://github.com/elixir-lotus/lotus_web/issues/138))

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Lotus.Web.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elixir-lotus/lotus_web"
-  @version "0.14.6"
+  @version "0.14.7"
 
   def project do
     [


### PR DESCRIPTION
## Issue reference

- Release prep for the fix in #138 (PR #139), shipping as v0.14.7.

## Changes

Release preparation only — no functional code changes:

- Bump `@version` `0.14.6` → `0.14.7` in `mix.exs`.
- Roll the `## Unreleased` CHANGELOG entries into a dated `## [0.14.7] - 2026-07-12` section, leaving `Unreleased` empty.

The shipped change itself (earmark → mdex, #139) already merged to `release/v0.14.x`.

## Checklist

- [x] Base is `release/v0.14.x` (not `main`)
- [x] Issue references present on all issue-tracked CHANGELOG bullets (`#138`)
- [x] `mix format` clean
- [x] `mix dialyzer` clean
- [x] `@version` and CHANGELOG section agree at `0.14.7`

## Notes for reviewers

Standard patch release-prep. After merge, `v0.14.7` will be published from the `release/v0.14.x` tip via `mix release`, followed by a GitHub release. The earmark fix is also being ported to `main` via a separate cherry-pick PR.
